### PR TITLE
Raspberry Pi で動かしてみる

### DIFF
--- a/ConsoleTestAppRaspberryPi/ConsoleTestAppRaspberryPi.csproj
+++ b/ConsoleTestAppRaspberryPi/ConsoleTestAppRaspberryPi.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <StartupObject>ConsoleTestAppRaspberryPi.Program</StartupObject>
+    <LangVersion>latest</LangVersion>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Ymf825.WiringPi\Ymf825.WiringPi.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/ConsoleTestAppRaspberryPi/Program.cs
+++ b/ConsoleTestAppRaspberryPi/Program.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Threading;
+using Ymf825;
+using Ymf825.IO;
+
+namespace ConsoleTestAppRaspberryPi
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Image type: {0}bit", Environment.Is64BitProcess ? "64" : "32");
+
+            using (var spiDevice = new WiringPiSpi())
+            using (var ymf825 = new Ymf825WiringPi(spiDevice))
+            {
+                var driver = new Ymf825Driver(ymf825);
+                driver.EnableSectionMode();
+
+                Console.WriteLine("Software Reset");
+                driver.ResetSoftware();
+
+                {
+                    Console.WriteLine("Tone Init");
+                    var tones = new ToneParameterCollection { [0] = ToneParameter.GetSine() };
+
+                    driver.Section(() =>
+                    {
+                        driver.WriteContentsData(tones, 0);
+                        driver.SetSequencerSetting(SequencerSetting.AllKeyOff | SequencerSetting.AllMute | SequencerSetting.AllEgReset |
+                                                   SequencerSetting.R_FIFOR | SequencerSetting.R_SEQ | SequencerSetting.R_FIFO);
+                    }, 1);
+
+                    driver.Section(() =>
+                    {
+                        driver.SetSequencerSetting(SequencerSetting.Reset);
+
+                        driver.SetToneFlag(0, false, true, true);
+                        driver.SetChannelVolume(31, true);
+                        driver.SetVibratoModuration(0);
+                        driver.SetFrequencyMultiplier(1, 0);
+                    });
+                }
+
+                var noteon = new Action<int>(key =>
+                {
+                    Ymf825Driver.GetFnumAndBlock(key, out var fnum, out var block, out var correction);
+                    Ymf825Driver.ConvertForFrequencyMultiplier(correction, out var integer, out var fraction);
+                    var freq = Ymf825Driver.CalcFrequency(fnum, block);
+                    Console.WriteLine("key: {0}, freq: {4:f1} Hz, fnum: {5:f0}, block: {6}, correction: {1:f3}, integer: {2}, fraction: {3}", key, correction, integer, fraction, freq, fnum, block);
+
+                    driver.Section(() =>
+                    {
+                        driver.SetVoiceNumber(0);
+                        driver.SetVoiceVolume(15);
+                        driver.SetFrequencyMultiplier(integer, fraction);
+                        driver.SetFnumAndBlock((int)Math.Round(fnum), block);
+                        driver.SetToneFlag(0, true, false, false);
+                    });
+                });
+
+                var noteoff = new Action(() =>
+                {
+                    driver.Section(() => driver.SetToneFlag(0, false, false, false));
+                });
+
+                var index = 0;
+                var score = new[]
+                {
+                    60, 62, 64, 65, 67, 69, 71, 72,
+                    72, 74, 76, 77, 79, 81, 83, 84,
+                    84, 83, 81, 79, 77, 76, 74, 72,
+                    72, 71, 69, 67, 65, 64, 62, 60
+                };
+                while (true)
+                {
+                    const int noteOnTime = 250;
+                    const int sleepTime = 0;
+
+                    noteon(score[index]);
+                    Thread.Sleep(noteOnTime);
+                    noteoff();
+
+                    Thread.Sleep(sleepTime);
+
+                    if (Console.KeyAvailable)
+                        break;
+
+                    index++;
+                    if (index >= score.Length)
+                        index = 0;
+                }
+
+                ymf825.ResetHardware();
+            }
+        }
+    }
+}

--- a/Ymf825.WiringPi/IO/WiringPiSpi.cs
+++ b/Ymf825.WiringPi/IO/WiringPiSpi.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Unosquare.RaspberryIO;
+using Unosquare.RaspberryIO.Gpio;
+
+namespace Ymf825.IO
+{
+    public sealed class WiringPiSpi : ISpi
+    {
+        public bool IsDisposed { get; private set; }
+
+        private SpiChannel SpiChannel { get; set; }
+
+        private GpioPin PinSS { get; set; }
+        private GpioPin PinRST { get; set; }
+
+        public WiringPiSpi()
+            : this(Pi.Gpio.Pin06, Pi.Gpio.Pin27)
+        {
+        }
+
+        public WiringPiSpi(GpioPin pinSS, GpioPin pinRST)
+        {
+            this.InitializeSpi();
+            this.InitializeGpio(pinSS, pinRST);
+        }
+
+        public void Dispose()
+            => this.IsDisposed = true;
+
+        public void SetCsTargetPin(byte pin)
+        {
+        }
+
+        public void Write(byte command, byte data)
+        {
+            try
+            {
+                this.PinSS.Write(GpioPinValue.Low);
+
+                this.SpiChannel.Write(new[] { command, data });
+            }
+            finally
+            {
+                this.PinSS.Write(GpioPinValue.High);
+            }
+        }
+
+        public void BurstWrite(byte command, byte[] data, int offset, int count)
+        {
+            try
+            {
+                this.PinSS.Write(GpioPinValue.Low);
+
+                var buffer = new byte[count + 1];
+
+                buffer[0] = command;
+                Array.Copy(data, offset, buffer, 1, count);
+
+                this.SpiChannel.Write(buffer);
+            }
+            finally
+            {
+                this.PinSS.Write(GpioPinValue.High);
+            }
+        }
+
+        public byte Read(byte command)
+        {
+            byte[] received;
+            try
+            {
+                this.PinSS.Write(GpioPinValue.Low);
+
+                this.SpiChannel.Write(new[] { command });
+
+                const byte dummy = 0x00;
+                received = this.SpiChannel.SendReceive(new[] { dummy });
+            }
+            finally
+            {
+                this.PinSS.Write(GpioPinValue.High);
+            }
+
+            return received[0];
+        }
+
+        public void Flush()
+        {
+        }
+
+        public void ResetHardware()
+        {
+            this.PinRST.Write(GpioPinValue.Low);
+
+            Thread.Sleep(1);
+
+            this.PinRST.Write(GpioPinValue.High);
+        }
+
+        private void InitializeSpi()
+        {
+            const int frequency = 10_000_000;
+
+            Pi.Spi.Channel0Frequency = frequency;
+            this.SpiChannel = Pi.Spi.Channel0;
+        }
+
+        private void InitializeGpio(GpioPin pinSS, GpioPin pinRST)
+        {
+            this.PinSS = pinSS;
+            this.PinSS.PinMode = GpioPinDriveMode.Output;
+            this.PinSS.Write(GpioPinValue.High);
+
+            this.PinRST = pinRST;
+            this.PinRST.PinMode = GpioPinDriveMode.Output;
+        }
+    }
+}

--- a/Ymf825.WiringPi/Ymf825.WiringPi.csproj
+++ b/Ymf825.WiringPi/Ymf825.WiringPi.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Unosquare.Raspberry.IO" Version="0.13.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Ymf825\Ymf825.csproj" />
   </ItemGroup>
 

--- a/Ymf825.WiringPi/Ymf825.WiringPi.csproj
+++ b/Ymf825.WiringPi/Ymf825.WiringPi.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <RootNamespace>Ymf825</RootNamespace>
+    <LangVersion>latest</LangVersion>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Ymf825\Ymf825.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Ymf825.WiringPi/Ymf825WiringPi.cs
+++ b/Ymf825.WiringPi/Ymf825WiringPi.cs
@@ -1,0 +1,14 @@
+﻿using Ymf825.IO;
+
+namespace Ymf825
+{
+    public class Ymf825WiringPi : Ymf825
+    {
+        public override TargetChip AvailableChip => TargetChip.Board0;
+
+        public Ymf825WiringPi(WiringPiSpi spiDevice)
+            : base(spiDevice)
+        {
+        }
+    }
+}

--- a/Ymf825.sln
+++ b/Ymf825.sln
@@ -7,6 +7,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ymf825", "Ymf825\Ymf825.csp
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsoleTestApp", "ConsoleTestApp\ConsoleTestApp.csproj", "{D42202FF-F8E3-4E37-BD10-C002A1AC39D6}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ymf825.WiringPi", "Ymf825.WiringPi\Ymf825.WiringPi.csproj", "{86B23AB5-31BE-4289-903B-476D313EA6CC}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConsoleTestAppRaspberryPi", "ConsoleTestAppRaspberryPi\ConsoleTestAppRaspberryPi.csproj", "{4AC5A44C-ACE6-47CC-B09D-4CF258EEAF1E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +25,14 @@ Global
 		{D42202FF-F8E3-4E37-BD10-C002A1AC39D6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D42202FF-F8E3-4E37-BD10-C002A1AC39D6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D42202FF-F8E3-4E37-BD10-C002A1AC39D6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{86B23AB5-31BE-4289-903B-476D313EA6CC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{86B23AB5-31BE-4289-903B-476D313EA6CC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{86B23AB5-31BE-4289-903B-476D313EA6CC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{86B23AB5-31BE-4289-903B-476D313EA6CC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4AC5A44C-ACE6-47CC-B09D-4CF258EEAF1E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4AC5A44C-ACE6-47CC-B09D-4CF258EEAF1E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4AC5A44C-ACE6-47CC-B09D-4CF258EEAF1E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4AC5A44C-ACE6-47CC-B09D-4CF258EEAF1E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Ymf825/IO/ISpi.cs
+++ b/Ymf825/IO/ISpi.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Ymf825.IO
+{
+    public interface ISpi : IDisposable
+    {
+        bool IsDisposed { get; }
+
+        /// <summary>
+        /// CS ピンを有効にする際の対象となる、ピン位置を表す整数値を設定します。
+        /// </summary>
+        /// <param name="pin">ピン位置を表す整数値。有効範囲は 0x08 から 0xf8 です。</param>
+        void SetCsTargetPin(byte pin);
+
+        /// <summary>
+        /// デバイスの送信キューをフラッシュし、コマンドを即時に実行します。
+        /// </summary>
+        void Flush();
+
+        /// <summary>
+        /// アドレスとデータを書き込むコマンドを送信キューに追加します。
+        /// </summary>
+        /// <param name="address">アドレスを表す 1 バイトの整数値。</param>
+        /// <param name="data">データを表す 1 バイトの整数値。</param>
+        void Write(byte address, byte data);
+
+        /// <summary>
+        /// アドレスと可変長のデータを書き込むコマンドを送信キューに追加します。
+        /// </summary>
+        /// <param name="address">アドレスを表す 1 バイトの整数値。</param>
+        /// <param name="data">データが格納されている <see cref="byte"/> 型の配列。</param>
+        /// <param name="offset">配列を読み出しを開始するオフセット値。</param>
+        /// <param name="count">配列から読み出すバイト数。</param>
+        void BurstWrite(byte address, byte[] data, int offset, int count);
+
+        /// <summary>
+        /// アドレスを指定して SPI デバイスから 1 バイトを読み出します。
+        /// このコマンドは即時に実行されます。
+        /// </summary>
+        /// <param name="address">アドレスを表す 1 バイトの整数値。</param>
+        /// <returns>SPI デバイスから返却されたデータ。</returns>
+        byte Read(byte address);
+
+        /// <summary>
+        /// YMF825 をハードウェアリセットします。
+        /// この命令は即時に実行されます。
+        /// </summary>
+        void ResetHardware();
+    }
+}

--- a/Ymf825/IO/Ymf825Spi.cs
+++ b/Ymf825/IO/Ymf825Spi.cs
@@ -6,7 +6,7 @@ namespace Ymf825.IO
     /// YMF825 と SPI による通信を行うための機能を提供します。
     /// </summary>
     /// <inheritdoc />
-    public class Ymf825Spi : Spi
+    public class Ymf825Spi : Spi, ISpi
     {
         #region -- Constructors --
 

--- a/Ymf825/Ymf825.cs
+++ b/Ymf825/Ymf825.cs
@@ -20,7 +20,7 @@ namespace Ymf825
         /// <summary>
         /// YMF825 との通信に使われる SPI インタフェースのオブジェクトを取得します。
         /// </summary>
-        public Ymf825Spi SpiInterface { get; }
+        public ISpi SpiInterface { get; }
 
         /// <summary>
         /// このオブジェクトが破棄されたかを表す真偽値を取得します。
@@ -90,6 +90,12 @@ namespace Ymf825
         {
             SpiInterface = new Ymf825Spi(spiDeviceIndex, csPin);
             SpiInterface.SetCsTargetPin(csPin);
+            CurrentTargetChip = AvailableChip;
+        }
+
+        protected Ymf825(ISpi spiDevice)
+        {
+            SpiInterface = spiDevice;
             CurrentTargetChip = AvailableChip;
         }
 


### PR DESCRIPTION
うごけー！ 🐱 🚌💨

## 動作環境

- Raspberry Pi 3 Model B
- Raspbian Stretch Lite (armhf)
  - `/boot/config.txt` に `dtparam=spi=on` が必要
- .NET Core 2.0 arm32
  - arm32版のSDKは存在しないので、x86なマシンでビルドしてからバイナリを持ってくる
- YMF825Board 🎹🎶
  - 回路の変更が必要: http://uda.la/fm/ の「5Vと3.3Vの2電源で使う場合」を参照

```
$ lsb_release -d
Description:    Raspbian GNU/Linux 9.1 (stretch)
$ uname -a
Linux raspberrypi 4.9.59-v7+ #1047 SMP Sun Oct 29 12:19:23 GMT 2017 armv7l GNU/Linux
$ cat /proc/cpuinfo
...
Hardware        : BCM2835
Revision        : a22082
...
```

対応表的な：

YMF825Board | Raspberry Pi
----------- | ------------
SS | Pin 22 (GPIO, BCM 25)
MOSI | Pin 19 (MOSI)
MISO | Pin 21 (MISO)
SCK | Pin 23 (SCLK)
GND | Pin 6 (GND)
5V | Pin 4 (5V)
RST_N | Pin 36 (GPIO, BCM 16)
3.3V | Pin 1 (3.3V)

## ⚠️ 既知の問題

- WiringPi を使用しているので、`/proc/cpuinfo` に Hardware, Revision の行が出力されない arm64 (aarch64) 環境ではエラーが発生する
  - #2 で作っている pigpio 版で解決する見込み