### PR TITLE
pigpiodを使用してSPI操作してみる

### DIFF
--- a/ConsoleTestAppRaspberryPi/ConsoleTestAppRaspberryPi.csproj
+++ b/ConsoleTestAppRaspberryPi/ConsoleTestAppRaspberryPi.csproj
@@ -9,6 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Mono.Options" Version="5.3.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Pigpio.Native\Pigpio.Native.csproj" />
     <ProjectReference Include="..\Pigpio.Socket\Pigpio.Socket.csproj" />
     <ProjectReference Include="..\Pigpio\Pigpio.csproj" />

--- a/ConsoleTestAppRaspberryPi/ConsoleTestAppRaspberryPi.csproj
+++ b/ConsoleTestAppRaspberryPi/ConsoleTestAppRaspberryPi.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Pigpio.Native\Pigpio.Native.csproj" />
     <ProjectReference Include="..\Pigpio.Socket\Pigpio.Socket.csproj" />
     <ProjectReference Include="..\Pigpio\Pigpio.csproj" />
     <ProjectReference Include="..\Ymf825.Pigpio\Ymf825.Pigpio.csproj" />

--- a/ConsoleTestAppRaspberryPi/ConsoleTestAppRaspberryPi.csproj
+++ b/ConsoleTestAppRaspberryPi/ConsoleTestAppRaspberryPi.csproj
@@ -2,13 +2,16 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <StartupObject>ConsoleTestAppRaspberryPi.Program</StartupObject>
     <LangVersion>latest</LangVersion>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Pigpio.Socket\Pigpio.Socket.csproj" />
+    <ProjectReference Include="..\Pigpio\Pigpio.csproj" />
+    <ProjectReference Include="..\Ymf825.Pigpio\Ymf825.Pigpio.csproj" />
     <ProjectReference Include="..\Ymf825.WiringPi\Ymf825.WiringPi.csproj" />
   </ItemGroup>
 

--- a/ConsoleTestAppRaspberryPi/Program.cs
+++ b/ConsoleTestAppRaspberryPi/Program.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿using Pigpio;
+using Pigpio.Api;
+using Pigpio.IO;
+using System;
 using System.Threading;
 using Ymf825;
 using Ymf825.IO;
@@ -11,8 +14,13 @@ namespace ConsoleTestAppRaspberryPi
         {
             Console.WriteLine("Image type: {0}bit", Environment.Is64BitProcess ? "64" : "32");
 
+#if false
             using (var spiDevice = new WiringPiSpi())
             using (var ymf825 = new Ymf825WiringPi(spiDevice))
+#else
+            using (var socket = new PigpioSocket("localhost", 8888))
+            using (var spiDevice = new PigpioSpi(new PigpioClient(new PigpioSocketApi(socket))))
+#endif
             {
                 var driver = new Ymf825Driver(ymf825);
                 driver.EnableSectionMode();

--- a/ConsoleTestAppRaspberryPi/Program.cs
+++ b/ConsoleTestAppRaspberryPi/Program.cs
@@ -1,4 +1,5 @@
-﻿using Pigpio;
+﻿using Mono.Options;
+using Pigpio;
 using Pigpio.Api;
 using Pigpio.IO;
 using System;
@@ -12,97 +13,161 @@ namespace ConsoleTestAppRaspberryPi
     {
         static void Main(string[] args)
         {
+            var options = ParseOptions(args);
+            if (options == null)
+                return;
+
             Console.WriteLine("Image type: {0}bit", Environment.Is64BitProcess ? "64" : "32");
 
-#if false
-            using (var spiDevice = new WiringPiSpi())
-            using (var ymf825 = new Ymf825WiringPi(spiDevice))
-#else
-//            using (var socket = new PigpioSocket("localhost", 8888))
-//            using (var spiDevice = new PigpioSpi(new PigpioClient(new PigpioSocketApi(socket))))
-            using (var spiDevice = new PigpioSpi(new PigpioClient(new PigpioNativeApi())))
-            using (var ymf825 = new Ymf825Pigpio(spiDevice))
-#endif
+            Ymf825.Ymf825 ymf825 = null;
+
+            switch (options.Value.Type)
             {
-                var driver = new Ymf825Driver(ymf825);
-                driver.EnableSectionMode();
-
-                Console.WriteLine("Software Reset");
-                driver.ResetSoftware();
-
-                {
-                    Console.WriteLine("Tone Init");
-                    var tones = new ToneParameterCollection { [0] = ToneParameter.GetSine() };
-
-                    driver.Section(() =>
+                case "pigpio":
                     {
-                        driver.WriteContentsData(tones, 0);
-                        driver.SetSequencerSetting(SequencerSetting.AllKeyOff | SequencerSetting.AllMute | SequencerSetting.AllEgReset |
-                                                   SequencerSetting.R_FIFOR | SequencerSetting.R_SEQ | SequencerSetting.R_FIFO);
-                    }, 1);
-
-                    driver.Section(() =>
+                        var pigpioApi = new PigpioNativeApi();
+                        var spiDevice = new PigpioSpi(new PigpioClient(pigpioApi));
+                        ymf825 = new Ymf825Pigpio(spiDevice);
+                    }
+                    break;
+                case "pigpiod":
                     {
-                        driver.SetSequencerSetting(SequencerSetting.Reset);
-
-                        driver.SetToneFlag(0, false, true, true);
-                        driver.SetChannelVolume(31, true);
-                        driver.SetVibratoModuration(0);
-                        driver.SetFrequencyMultiplier(1, 0);
-                    });
-                }
-
-                var noteon = new Action<int>(key =>
-                {
-                    Ymf825Driver.GetFnumAndBlock(key, out var fnum, out var block, out var correction);
-                    Ymf825Driver.ConvertForFrequencyMultiplier(correction, out var integer, out var fraction);
-                    var freq = Ymf825Driver.CalcFrequency(fnum, block);
-                    Console.WriteLine("key: {0}, freq: {4:f1} Hz, fnum: {5:f0}, block: {6}, correction: {1:f3}, integer: {2}, fraction: {3}", key, correction, integer, fraction, freq, fnum, block);
-
-                    driver.Section(() =>
+                        var (_, hostname, port) = options.Value;
+                        var pigpioApi = new PigpioSocketApi(new PigpioSocket(hostname, port));
+                        var spiDevice = new PigpioSpi(new PigpioClient(pigpioApi));
+                        ymf825 = new Ymf825Pigpio(spiDevice);
+                    }
+                    break;
+                case "wiringpi":
+                default:
                     {
-                        driver.SetVoiceNumber(0);
-                        driver.SetVoiceVolume(15);
-                        driver.SetFrequencyMultiplier(integer, fraction);
-                        driver.SetFnumAndBlock((int)Math.Round(fnum), block);
-                        driver.SetToneFlag(0, true, false, false);
-                    });
-                });
-
-                var noteoff = new Action(() =>
-                {
-                    driver.Section(() => driver.SetToneFlag(0, false, false, false));
-                });
-
-                var index = 0;
-                var score = new[]
-                {
-                    60, 62, 64, 65, 67, 69, 71, 72,
-                    72, 74, 76, 77, 79, 81, 83, 84,
-                    84, 83, 81, 79, 77, 76, 74, 72,
-                    72, 71, 69, 67, 65, 64, 62, 60
-                };
-                while (true)
-                {
-                    const int noteOnTime = 250;
-                    const int sleepTime = 0;
-
-                    noteon(score[index]);
-                    Thread.Sleep(noteOnTime);
-                    noteoff();
-
-                    Thread.Sleep(sleepTime);
-
-                    if (Console.KeyAvailable)
-                        break;
-
-                    index++;
-                    if (index >= score.Length)
-                        index = 0;
-                }
-
-                ymf825.ResetHardware();
+                        var spiDevice = new WiringPiSpi();
+                        ymf825 = new Ymf825WiringPi(spiDevice);
+                    }
+                    break;
             }
+
+            var driver = new Ymf825Driver(ymf825);
+            SamplePlay(driver);
+        }
+
+        private static (string Type, string Hostname, int Port)? ParseOptions(string[] args)
+        {
+            var type = (string)null;
+            var hostname = "localhost";
+            var port = 8888;
+            var help = false;
+
+            var options = new OptionSet
+            {
+                { "t|type=", "Specify connection type (wiringpi, pigpio, pigpiod) [required]", x => type = x },
+                { "h|host=", "The hostname of pigpiod [default: localhost]", x => hostname = x },
+                { "p|port=", "The port number for pigpiod connection [default: 8888]", (int x) => port = x },
+                { "help", "Show this help message", _ => help = true },
+            };
+
+            try
+            {
+                options.Parse(args);
+            }
+            catch (OptionException ex)
+            {
+                Console.WriteLine($"{args[0]}: {ex.Message}");
+                Console.WriteLine($"Try `{args[0]} --help' for more information.");
+                return null;
+            }
+
+            if (type == null)
+                help = true;
+
+            if (help)
+            {
+                options.WriteOptionDescriptions(Console.Out);
+                return null;
+            }
+
+            return (type, hostname, port);
+        }
+
+        private static void SamplePlay(Ymf825Driver driver)
+        {
+            driver.EnableSectionMode();
+
+            Console.WriteLine("Software Reset");
+            driver.ResetSoftware();
+
+            {
+                Console.WriteLine("Tone Init");
+                var tones = new ToneParameterCollection { [0] = ToneParameter.GetSine() };
+
+                driver.Section(() =>
+                {
+                    driver.WriteContentsData(tones, 0);
+                    driver.SetSequencerSetting(SequencerSetting.AllKeyOff | SequencerSetting.AllMute | SequencerSetting.AllEgReset |
+                                                SequencerSetting.R_FIFOR | SequencerSetting.R_SEQ | SequencerSetting.R_FIFO);
+                }, 1);
+
+                driver.Section(() =>
+                {
+                    driver.SetSequencerSetting(SequencerSetting.Reset);
+
+                    driver.SetToneFlag(0, false, true, true);
+                    driver.SetChannelVolume(31, true);
+                    driver.SetVibratoModuration(0);
+                    driver.SetFrequencyMultiplier(1, 0);
+                });
+            }
+
+            var noteon = new Action<int>(key =>
+            {
+                Ymf825Driver.GetFnumAndBlock(key, out var fnum, out var block, out var correction);
+                Ymf825Driver.ConvertForFrequencyMultiplier(correction, out var integer, out var fraction);
+                var freq = Ymf825Driver.CalcFrequency(fnum, block);
+                Console.WriteLine("key: {0}, freq: {4:f1} Hz, fnum: {5:f0}, block: {6}, correction: {1:f3}, integer: {2}, fraction: {3}", key, correction, integer, fraction, freq, fnum, block);
+
+                driver.Section(() =>
+                {
+                    driver.SetVoiceNumber(0);
+                    driver.SetVoiceVolume(15);
+                    driver.SetFrequencyMultiplier(integer, fraction);
+                    driver.SetFnumAndBlock((int)Math.Round(fnum), block);
+                    driver.SetToneFlag(0, true, false, false);
+                });
+            });
+
+            var noteoff = new Action(() =>
+            {
+                driver.Section(() => driver.SetToneFlag(0, false, false, false));
+            });
+
+            var index = 0;
+            var score = new[]
+            {
+                60, 62, 64, 65, 67, 69, 71, 72,
+                72, 74, 76, 77, 79, 81, 83, 84,
+                84, 83, 81, 79, 77, 76, 74, 72,
+                72, 71, 69, 67, 65, 64, 62, 60
+            };
+            while (true)
+            {
+                const int noteOnTime = 250;
+                const int sleepTime = 0;
+
+                noteon(score[index]);
+                Thread.Sleep(noteOnTime);
+                noteoff();
+
+                Thread.Sleep(sleepTime);
+
+                if (Console.KeyAvailable)
+                    break;
+
+                index++;
+                if (index >= score.Length)
+                    index = 0;
+            }
+
+            driver.ResetHardware();
         }
     }
 }

--- a/ConsoleTestAppRaspberryPi/Program.cs
+++ b/ConsoleTestAppRaspberryPi/Program.cs
@@ -21,7 +21,9 @@ namespace ConsoleTestAppRaspberryPi
 
             Ymf825.Ymf825 ymf825 = null;
 
-            switch (options.Value.Type)
+            var (type, _, _, board) = options.Value;
+
+            switch (type)
             {
                 case "pigpio":
                     {
@@ -32,7 +34,7 @@ namespace ConsoleTestAppRaspberryPi
                     break;
                 case "pigpiod":
                     {
-                        var (_, hostname, port) = options.Value;
+                        var (_, hostname, port, _) = options.Value;
                         var pigpioApi = new PigpioSocketApi(new PigpioSocket(hostname, port));
                         var spiDevice = new PigpioSpi(new PigpioClient(pigpioApi));
                         ymf825 = new Ymf825Pigpio(spiDevice);
@@ -47,15 +49,18 @@ namespace ConsoleTestAppRaspberryPi
                     break;
             }
 
+            ymf825.ChangeTargetDevice((TargetChip)board);
+
             var driver = new Ymf825Driver(ymf825);
             SamplePlay(driver);
         }
 
-        private static (string Type, string Hostname, int Port)? ParseOptions(string[] args)
+        private static (string Type, string Hostname, int Port, int Board)? ParseOptions(string[] args)
         {
             var type = (string)null;
             var hostname = "localhost";
             var port = 8888;
+            var board = 1;
             var help = false;
 
             var options = new OptionSet
@@ -63,6 +68,7 @@ namespace ConsoleTestAppRaspberryPi
                 { "t|type=", "Specify connection type (wiringpi, pigpio, pigpiod) [required]", x => type = x },
                 { "h|host=", "The hostname of pigpiod [default: localhost]", x => hostname = x },
                 { "p|port=", "The port number for pigpiod connection [default: 8888]", (int x) => port = x },
+                { "b|board=", "The board number [default: 1]", (int x) => board = x },
                 { "help", "Show this help message", _ => help = true },
             };
 
@@ -86,7 +92,7 @@ namespace ConsoleTestAppRaspberryPi
                 return null;
             }
 
-            return (type, hostname, port);
+            return (type, hostname, port, board);
         }
 
         private static void SamplePlay(Ymf825Driver driver)

--- a/ConsoleTestAppRaspberryPi/Program.cs
+++ b/ConsoleTestAppRaspberryPi/Program.cs
@@ -18,8 +18,10 @@ namespace ConsoleTestAppRaspberryPi
             using (var spiDevice = new WiringPiSpi())
             using (var ymf825 = new Ymf825WiringPi(spiDevice))
 #else
-            using (var socket = new PigpioSocket("localhost", 8888))
-            using (var spiDevice = new PigpioSpi(new PigpioClient(new PigpioSocketApi(socket))))
+//            using (var socket = new PigpioSocket("localhost", 8888))
+//            using (var spiDevice = new PigpioSpi(new PigpioClient(new PigpioSocketApi(socket))))
+            using (var spiDevice = new PigpioSpi(new PigpioClient(new PigpioNativeApi())))
+            using (var ymf825 = new Ymf825Pigpio(spiDevice))
 #endif
             {
                 var driver = new Ymf825Driver(ymf825);

--- a/Pigpio.Native/Api/NativeMethods.cs
+++ b/Pigpio.Native/Api/NativeMethods.cs
@@ -1,0 +1,49 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Pigpio.Api
+{
+    internal static class NativeMethods
+    {
+        public const string PigpioLibrary = "libpigpio.so";
+
+#pragma warning disable IDE1006 // Naming rule violation: These words must begin with upper case characters
+
+        [DllImport(PigpioLibrary, EntryPoint = nameof(gpioInitialise))]
+        public static extern int gpioInitialise();
+
+        [DllImport(PigpioLibrary, EntryPoint = nameof(gpioTerminate))]
+        public static extern void gpioTerminate();
+
+        [DllImport(PigpioLibrary, EntryPoint = nameof(gpioSetMode))]
+        public static extern int gpioSetMode(int gpio, int mode);
+
+        [DllImport(PigpioLibrary, EntryPoint = nameof(gpioGetMode))]
+        public static extern int gpioGetMode(int gpio);
+
+        [DllImport(PigpioLibrary, EntryPoint = nameof(gpioSetPullUpDown))]
+        public static extern int gpioSetPullUpDown(int gpio, int pud);
+
+        [DllImport(PigpioLibrary, EntryPoint = nameof(gpioRead))]
+        public static extern int gpioRead(int gpio);
+
+        [DllImport(PigpioLibrary, EntryPoint = nameof(gpioWrite))]
+        public static extern int gpioWrite(int gpio, int level);
+
+        [DllImport(PigpioLibrary, EntryPoint = nameof(spiOpen))]
+        public static extern int spiOpen(int spiChan, int baud, int spiFlags);
+
+        [DllImport(PigpioLibrary, EntryPoint = nameof(spiClose))]
+        public static extern int spiClose(int handle);
+
+        [DllImport(PigpioLibrary, EntryPoint = nameof(spiRead))]
+        public static extern unsafe int spiRead(int handle, byte* buf, int count);
+
+        [DllImport(PigpioLibrary, EntryPoint = nameof(spiWrite))]
+        public static extern unsafe int spiWrite(int handle, byte* buf, int count);
+
+        [DllImport(PigpioLibrary, EntryPoint = nameof(spiXfer))]
+        public static extern unsafe int spiXfer(int handle, byte* txBuf, byte* rxBuf, int count);
+
+#pragma warning restore IDE1006
+    }
+}

--- a/Pigpio.Native/Api/PigpioNativeApi.cs
+++ b/Pigpio.Native/Api/PigpioNativeApi.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace Pigpio.Api
+{
+    public sealed class PigpioNativeApi : IPigpioApi
+    {
+        public PigpioNativeApi()
+            => this.CheckError(() => NativeMethods.gpioInitialise());
+
+        ~PigpioNativeApi()
+            => this.Dispose();
+
+        public void Dispose()
+            => NativeMethods.gpioTerminate();
+
+        public void SetMode(int gpio, int mode)
+            => this.CheckError(() => NativeMethods.gpioSetMode(gpio, mode));
+
+        public int GetMode(int gpio)
+            => this.CheckError(() => NativeMethods.gpioGetMode(gpio));
+
+        public void SetPullUpDown(int gpio, int pud)
+            => this.CheckError(() => NativeMethods.gpioSetPullUpDown(gpio, pud));
+
+        public int GpioRead(int gpio)
+            => this.CheckError(() => NativeMethods.gpioRead(gpio));
+
+        public void GpioWrite(int gpio, int level)
+            => this.CheckError(() => NativeMethods.gpioWrite(gpio, level));
+
+        public int SpiOpen(int channel, int baud, int flags)
+            => this.CheckError(() => NativeMethods.spiOpen(channel, baud, flags));
+
+        public void SpiClose(int handle)
+            => this.CheckError(() => NativeMethods.spiClose(handle));
+
+        public unsafe void SpiRead(int handle, Span<byte> buf)
+        {
+            fixed (byte* p = &MemoryMarshal.GetReference(buf))
+            {
+                var ret = NativeMethods.spiRead(handle, p, buf.Length);
+                this.CheckError(ret);
+            }
+        }
+
+        public unsafe void SpiWrite(int handle, Span<byte> buf)
+        {
+            fixed (byte* p = &MemoryMarshal.GetReference(buf))
+            {
+                var ret = NativeMethods.spiWrite(handle, p, buf.Length);
+                this.CheckError(ret);
+            }
+        }
+
+        public unsafe void SpiXfer(int handle, Span<byte> tx, Span<byte> rx)
+        {
+            fixed (byte* ptx = &MemoryMarshal.GetReference(tx))
+            fixed (byte* prx = &MemoryMarshal.GetReference(rx))
+            {
+                var ret = NativeMethods.spiXfer(handle, ptx, prx, tx.Length);
+                this.CheckError(ret);
+            }
+        }
+
+        private int CheckError(Func<int> func)
+            => this.CheckError(func());
+
+        private int CheckError(int ret)
+            => ret >= 0 ? ret : throw new PigpioApiException($"code = {ret}");
+    }
+}

--- a/Pigpio.Native/Pigpio.Native.csproj
+++ b/Pigpio.Native/Pigpio.Native.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <RootNamespace>Pigpio</RootNamespace>
+    <LangVersion>latest</LangVersion>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Pigpio\Pigpio.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Pigpio.Socket/Api/PigpioSocketApi.cs
+++ b/Pigpio.Socket/Api/PigpioSocketApi.cs
@@ -1,6 +1,10 @@
 ﻿using Pigpio.IO;
 using System;
+#if !NETSTANDARD2_0
 using System.Buffers.Binary;
+#else
+using Pigpio.Polyfills;
+#endif
 
 namespace Pigpio.Api
 {
@@ -19,7 +23,11 @@ namespace Pigpio.Api
 
         public void Send(PigpioCommand cmd, int p1, int p2, int p3, Span<byte> ext)
         {
+#if !NETSTANDARD2_0
             Span<byte> buffer = stackalloc byte[16];
+#else
+            Span<byte> buffer = new byte[16];
+#endif
 
             var request = new PigpioMessage(buffer, ext);
             request.SetAll(cmd, p1, p2, p3);
@@ -32,7 +40,11 @@ namespace Pigpio.Api
 
         public int Receive(Span<byte> ext)
         {
+#if !NETSTANDARD2_0
             Span<byte> buffer = stackalloc byte[16];
+#else
+            Span<byte> buffer = new byte[16];
+#endif
 
             var response = new PigpioMessage(buffer, ext);
             this.socket.Receive(response);

--- a/Pigpio.Socket/Api/PigpioSocketApi.cs
+++ b/Pigpio.Socket/Api/PigpioSocketApi.cs
@@ -1,0 +1,52 @@
+﻿using Pigpio.IO;
+using System;
+using System.Buffers.Binary;
+
+namespace Pigpio.Api
+{
+    public partial class PigpioSocketApi : IPigpioApi
+    {
+        private readonly PigpioSocket socket;
+
+        public PigpioSocketApi(PigpioSocket socket)
+            => this.socket = socket;
+
+        public void Dispose()
+            => this.socket.Dispose();
+
+        public void Send(PigpioCommand cmd, int p1, int p2, int p3)
+            => this.Send(cmd, p1, p2, p3, Span<byte>.Empty);
+
+        public void Send(PigpioCommand cmd, int p1, int p2, int p3, Span<byte> ext)
+        {
+            Span<byte> buffer = stackalloc byte[16];
+
+            var request = new PigpioMessage(buffer, ext);
+            request.SetAll(cmd, p1, p2, p3);
+
+            this.socket.Send(request);
+        }
+
+        public int Receive()
+            => this.Receive(Span<byte>.Empty);
+
+        public int Receive(Span<byte> ext)
+        {
+            Span<byte> buffer = stackalloc byte[16];
+
+            var response = new PigpioMessage(buffer, ext);
+            this.socket.Receive(response);
+
+            var ret = BinaryPrimitives.ReadInt32LittleEndian(response.P3);
+            this.ThrowIfError(ret);
+
+            return ret;
+        }
+
+        private void ThrowIfError(int ret)
+        {
+            if (ret < 0)
+                throw new PigpioApiException($"code = {ret}");
+        }
+    }
+}

--- a/Pigpio.Socket/Api/PigpioSocketApiBeginner.cs
+++ b/Pigpio.Socket/Api/PigpioSocketApiBeginner.cs
@@ -1,0 +1,41 @@
+﻿using Pigpio.IO;
+
+namespace Pigpio.Api
+{
+    public partial class PigpioSocketApi
+    {
+        public void SetMode(int gpio, int mode)
+        {
+            this.Send(PigpioCommand.MODES, gpio, mode, 0);
+            this.Receive();
+        }
+
+        public int GetMode(int gpio)
+        {
+            this.Send(PigpioCommand.MODEG, gpio, 0, 0);
+            var mode = this.Receive();
+
+            return mode;
+        }
+
+        public void SetPullUpDown(int gpio, int pud)
+        {
+            this.Send(PigpioCommand.PUD, gpio, pud, 0);
+            this.Receive();
+        }
+
+        public int GpioRead(int gpio)
+        {
+            this.Send(PigpioCommand.READ, gpio, 0, 0);
+            var level = this.Receive();
+
+            return level;
+        }
+
+        public void GpioWrite(int gpio, int level)
+        {
+            this.Send(PigpioCommand.WRITE, gpio, level, 0);
+            this.Receive();
+        }
+    }
+}

--- a/Pigpio.Socket/Api/PigpioSocketApiSpi.cs
+++ b/Pigpio.Socket/Api/PigpioSocketApiSpi.cs
@@ -1,6 +1,10 @@
 ﻿using Pigpio.IO;
 using System;
+#if !NETSTANDARD2_0
 using System.Buffers.Binary;
+#else
+using Pigpio.Polyfills;
+#endif
 
 namespace Pigpio.Api
 {
@@ -8,7 +12,11 @@ namespace Pigpio.Api
     {
         public int SpiOpen(int channel, int baud, int flags)
         {
+#if !NETSTANDARD2_0
             Span<byte> ext = stackalloc byte[4];
+#else
+            Span<byte> ext = new byte[4];
+#endif
 
             BinaryPrimitives.WriteInt32LittleEndian(ext.Slice(0, 4), flags);
 

--- a/Pigpio.Socket/Api/PigpioSocketApiSpi.cs
+++ b/Pigpio.Socket/Api/PigpioSocketApiSpi.cs
@@ -1,0 +1,48 @@
+﻿using Pigpio.IO;
+using System;
+using System.Buffers.Binary;
+
+namespace Pigpio.Api
+{
+    public partial class PigpioSocketApi
+    {
+        public int SpiOpen(int channel, int baud, int flags)
+        {
+            Span<byte> ext = stackalloc byte[4];
+
+            BinaryPrimitives.WriteInt32LittleEndian(ext.Slice(0, 4), flags);
+
+            this.Send(PigpioCommand.SPIO, channel, baud, 4, ext);
+            var handle = this.Receive();
+
+            return handle;
+        }
+
+        public void SpiClose(int handle)
+        {
+            this.Send(PigpioCommand.SPIC, handle, 0, 0);
+            this.Receive();
+        }
+
+        public void SpiRead(int handle, Span<byte> buf)
+        {
+            this.Send(PigpioCommand.SPIR, handle, buf.Length, 0);
+            this.Receive(buf);
+        }
+
+        public void SpiWrite(int handle, Span<byte> buf)
+        {
+            this.Send(PigpioCommand.SPIW, handle, 0, buf.Length, buf);
+            this.Receive();
+        }
+
+        public void SpiXfer(int handle, Span<byte> tx, Span<byte> rx)
+        {
+            if (tx.Length != rx.Length)
+                throw new ArgumentException("The tx and rx length are must be same.", nameof(rx));
+
+            this.Send(PigpioCommand.SPIX, handle, 0, tx.Length, tx);
+            this.Receive(rx);
+        }
+    }
+}

--- a/Pigpio.Socket/IO/PigpioCommand.cs
+++ b/Pigpio.Socket/IO/PigpioCommand.cs
@@ -1,0 +1,16 @@
+﻿namespace Pigpio.IO
+{
+    public enum PigpioCommand
+    {
+        MODES = 0,
+        MODEG = 1,
+        PUD = 2,
+        READ = 3,
+        WRITE = 4,
+        SPIO = 71,
+        SPIC = 72,
+        SPIR = 73,
+        SPIW = 74,
+        SPIX = 75,
+    }
+}

--- a/Pigpio.Socket/IO/PigpioMessage.cs
+++ b/Pigpio.Socket/IO/PigpioMessage.cs
@@ -1,5 +1,9 @@
 ﻿using System;
+#if !NETSTANDARD2_0
 using System.Buffers.Binary;
+#else
+using Pigpio.Polyfills;
+#endif
 
 namespace Pigpio.IO
 {

--- a/Pigpio.Socket/IO/PigpioMessage.cs
+++ b/Pigpio.Socket/IO/PigpioMessage.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Buffers.Binary;
+
+namespace Pigpio.IO
+{
+    public readonly ref struct PigpioMessage
+    {
+        public Span<byte> Span { get; }
+        public Span<byte> ExtSpan { get; }
+
+        public Span<byte> Command
+            => this.Span.Slice(0, 4);
+
+        public Span<byte> P1
+            => this.Span.Slice(4, 4);
+
+        public Span<byte> P2
+            => this.Span.Slice(8, 4);
+
+        public Span<byte> P3
+            => this.Span.Slice(12, 4);
+
+        public PigpioMessage(Span<byte> span, Span<byte> ext)
+        {
+            this.Span = span;
+            this.ExtSpan = ext;
+        }
+
+        public void SetAll(PigpioCommand cmd, int p1, int p2, int p3)
+        {
+            BinaryPrimitives.WriteInt32LittleEndian(this.Command, (int)cmd);
+            BinaryPrimitives.WriteInt32LittleEndian(this.P1, p1);
+            BinaryPrimitives.WriteInt32LittleEndian(this.P2, p2);
+            BinaryPrimitives.WriteInt32LittleEndian(this.P3, p3);
+        }
+    }
+}

--- a/Pigpio.Socket/IO/PigpioSocket.cs
+++ b/Pigpio.Socket/IO/PigpioSocket.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.IO;
 using System.Net.Sockets;
+#if NETSTANDARD2_0
+using Pigpio.Polyfills;
+#endif
 
 namespace Pigpio.IO
 {

--- a/Pigpio.Socket/IO/PigpioSocket.cs
+++ b/Pigpio.Socket/IO/PigpioSocket.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.IO;
+using System.Net.Sockets;
+
+namespace Pigpio.IO
+{
+    public sealed class PigpioSocket : IDisposable
+    {
+        private readonly TcpClient tcpClient;
+        private Stream stream;
+
+        public PigpioSocket(string hostname, int port) : this()
+            => this.Connect(hostname, port);
+
+        public PigpioSocket()
+        {
+            this.tcpClient = new TcpClient
+            {
+                NoDelay = true,
+            };
+        }
+
+        public void Connect(string hostname, int port)
+        {
+            this.tcpClient.Connect(hostname, port);
+            this.stream = this.tcpClient.GetStream();
+        }
+
+        public void Dispose()
+        {
+            this.stream.Dispose();
+            this.tcpClient.Dispose();
+        }
+
+        public void Send(PigpioMessage request)
+        {
+            this.stream.Write(request.Span);
+
+            if (!request.ExtSpan.IsEmpty)
+                this.stream.Write(request.ExtSpan);
+        }
+
+        public void Receive(PigpioMessage response)
+        {
+            this.stream.Read(response.Span);
+
+            if (!response.ExtSpan.IsEmpty)
+                this.stream.Read(response.ExtSpan);
+        }
+    }
+}

--- a/Pigpio.Socket/Pigpio.Socket.csproj
+++ b/Pigpio.Socket/Pigpio.Socket.csproj
@@ -2,14 +2,13 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <RootNamespace>Ymf825</RootNamespace>
+    <RootNamespace>Pigpio</RootNamespace>
     <LangVersion>latest</LangVersion>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Pigpio\Pigpio.csproj" />
-    <ProjectReference Include="..\Ymf825\Ymf825.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Pigpio.Socket/Pigpio.Socket.csproj
+++ b/Pigpio.Socket/Pigpio.Socket.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
     <RootNamespace>Pigpio</RootNamespace>
     <LangVersion>latest</LangVersion>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>

--- a/Pigpio.Socket/Polyfills/BinaryPrimitives.cs
+++ b/Pigpio.Socket/Polyfills/BinaryPrimitives.cs
@@ -1,0 +1,29 @@
+﻿#if NETSTANDARD2_0
+using System;
+
+namespace Pigpio.Polyfills
+{
+    internal static class BinaryPrimitives
+    {
+        public static int ReadInt32LittleEndian(ReadOnlySpan<byte> buffer)
+        {
+            var value = 0;
+
+            value |= buffer[3] << 24;
+            value |= buffer[2] << 16;
+            value |= buffer[1] << 8;
+            value |= buffer[0];
+
+            return value;
+        }
+
+        public static void WriteInt32LittleEndian(Span<byte> buffer, int value)
+        {
+            buffer[3] = (byte)((value & 0xff000000) >> 24);
+            buffer[2] = (byte)((value & 0x00ff0000) >> 16);
+            buffer[1] = (byte)((value & 0x0000ff00) >> 8);
+            buffer[0] = (byte)(value & 0x000000ff);
+        }
+    }
+}
+#endif

--- a/Pigpio.Socket/Polyfills/StreamExtentions.cs
+++ b/Pigpio.Socket/Polyfills/StreamExtentions.cs
@@ -1,0 +1,20 @@
+﻿#if NETSTANDARD2_0
+using System;
+using System.IO;
+
+namespace Pigpio.Polyfills
+{
+    internal static class StreamExtentions
+    {
+        public static void Read(this Stream stream, Span<byte> destination)
+        {
+            var buffer = new byte[destination.Length];
+            stream.Read(buffer, 0, buffer.Length);
+            buffer.CopyTo(destination);
+        }
+
+        public static void Write(this Stream stream, ReadOnlySpan<byte> source)
+            => stream.Write(source.ToArray(), 0, source.Length);
+    }
+}
+#endif

--- a/Pigpio/Api/Constants.cs
+++ b/Pigpio/Api/Constants.cs
@@ -1,0 +1,17 @@
+﻿namespace Pigpio.Api
+{
+    public static class Constants
+    {
+        public const int PI_INPUT = 0;
+        public const int PI_OUTPUT = 1;
+        public const int PI_ALT0 = 4;
+        public const int PI_ALT1 = 5;
+        public const int PI_ALT2 = 6;
+        public const int PI_ALT3 = 7;
+        public const int PI_ALT4 = 3;
+        public const int PI_ALT5 = 2;
+
+        public const int LOW = 0;
+        public const int HIGH = 1;
+    }
+}

--- a/Pigpio/Api/IPigpioApi.cs
+++ b/Pigpio/Api/IPigpioApi.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace Pigpio.Api
+{
+    public partial interface IPigpioApi : IDisposable
+    {
+        void SetMode(int gpio, int mode);
+        int GetMode(int gpio);
+        void SetPullUpDown(int gpio, int pud);
+        int GpioRead(int gpio);
+        void GpioWrite(int gpio, int level);
+
+        int SpiOpen(int channel, int baud, int flags);
+        void SpiClose(int handle);
+        void SpiRead(int handle, Span<byte> buf);
+        void SpiWrite(int handle, Span<byte> buf);
+        void SpiXfer(int handle, Span<byte> tx, Span<byte> rx);
+    }
+}

--- a/Pigpio/Api/PigpioApiException.cs
+++ b/Pigpio/Api/PigpioApiException.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace Pigpio.Api
+{
+    [Serializable]
+    public class PigpioApiException : Exception
+    {
+        public PigpioApiException()
+            : base()
+        {
+        }
+
+        public PigpioApiException(string message)
+            : base(message)
+        {
+        }
+
+        public PigpioApiException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        protected PigpioApiException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}

--- a/Pigpio/GpioManager.cs
+++ b/Pigpio/GpioManager.cs
@@ -1,0 +1,31 @@
+﻿using Pigpio.Api;
+using System.Collections.Generic;
+
+namespace Pigpio
+{
+    public class GpioManager
+    {
+        private IPigpioApi api;
+        private Dictionary<int, GpioPin> pins;
+
+        public GpioManager(IPigpioApi api)
+        {
+            this.api = api;
+            this.pins = new Dictionary<int, GpioPin>();
+        }
+
+        public GpioPin this[int p]
+        {
+            get
+            {
+                if (this.pins.TryGetValue(p, out var pin))
+                    return pin;
+
+                pin = new GpioPin(this.api, p);
+                this.pins[p] = pin;
+
+                return pin;
+            }
+        }
+    }
+}

--- a/Pigpio/GpioPin.cs
+++ b/Pigpio/GpioPin.cs
@@ -1,0 +1,53 @@
+﻿using Pigpio.Api;
+
+namespace Pigpio
+{
+    public class GpioPin
+    {
+        public int Pin { get; }
+
+        private IPigpioApi Api { get; }
+
+        public GpioPin(IPigpioApi api, int pin)
+        {
+            this.Api = api;
+            this.Pin = pin;
+        }
+
+        public GpioPinMode PinMode
+        {
+            get => (GpioPinMode)this.Api.GetMode(this.Pin);
+            set => this.Api.SetMode(this.Pin, (int)value);
+        }
+
+        public void SetPullUpDown(int pud)
+            => this.Api.SetPullUpDown(this.Pin, pud);
+
+        public int Read()
+            => this.Api.GpioRead(this.Pin);
+
+        public void Write(bool level)
+            => this.Write(level ? GpioPinLevel.High : GpioPinLevel.Low);
+
+        public void Write(GpioPinLevel level)
+            => this.Api.GpioWrite(this.Pin, (int)level);
+    }
+
+    public enum GpioPinMode
+    {
+        Input = Constants.PI_INPUT,
+        Output = Constants.PI_OUTPUT,
+        Alt0 = Constants.PI_ALT0,
+        Alt1 = Constants.PI_ALT1,
+        Alt2 = Constants.PI_ALT2,
+        Alt3 = Constants.PI_ALT3,
+        Alt4 = Constants.PI_ALT4,
+        Alt5 = Constants.PI_ALT5,
+    }
+
+    public enum GpioPinLevel
+    {
+        Low = Constants.LOW,
+        High = Constants.HIGH,
+    }
+}

--- a/Pigpio/Pigpio.csproj
+++ b/Pigpio/Pigpio.csproj
@@ -2,14 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <RootNamespace>Ymf825</RootNamespace>
     <LangVersion>latest</LangVersion>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
   </PropertyGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\Pigpio\Pigpio.csproj" />
-    <ProjectReference Include="..\Ymf825\Ymf825.csproj" />
-  </ItemGroup>
 
 </Project>

--- a/Pigpio/Pigpio.csproj
+++ b/Pigpio/Pigpio.csproj
@@ -1,9 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
   </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Memory" Version="4.4.0-preview1-25305-02" />
+  </ItemGroup>
 
 </Project>

--- a/Pigpio/PigpioClient.cs
+++ b/Pigpio/PigpioClient.cs
@@ -1,0 +1,20 @@
+﻿using Pigpio.Api;
+
+namespace Pigpio
+{
+    public sealed class PigpioClient
+    {
+        public GpioManager Gpio { get; }
+        public SpiManager Spi { get; }
+
+        private readonly IPigpioApi api;
+
+        public PigpioClient(IPigpioApi api)
+        {
+            this.api = api;
+
+            this.Gpio = new GpioManager(api);
+            this.Spi = new SpiManager(api);
+        }
+    }
+}

--- a/Pigpio/SpiChannel.cs
+++ b/Pigpio/SpiChannel.cs
@@ -1,0 +1,43 @@
+﻿using Pigpio.Api;
+using System;
+
+namespace Pigpio
+{
+    public sealed class SpiChannel : IDisposable
+    {
+        public int Channel { get; }
+        public int? Handle { get; private set; }
+
+        public IPigpioApi Api { get; }
+
+        public SpiChannel(IPigpioApi api, int channel)
+        {
+            this.Api = api;
+            this.Channel = channel;
+        }
+
+        public void Dispose()
+            => this.Close();
+
+        public void Open(int baud, int flags)
+            => this.Handle = this.Api.SpiOpen(this.Channel, baud, flags);
+
+        public void Close()
+        {
+            if (this.Handle == null)
+                return;
+
+            this.Api.SpiClose(this.Handle.Value);
+            this.Handle = null;
+        }
+
+        public void Read(Span<byte> buffer)
+            => this.Api.SpiRead(this.Handle.Value, buffer);
+
+        public void Write(Span<byte> buffer)
+            => this.Api.SpiWrite(this.Handle.Value, buffer);
+
+        public void Xfer(Span<byte> tx, Span<byte> rx)
+            => this.Api.SpiXfer(this.Handle.Value, tx, rx);
+    }
+}

--- a/Pigpio/SpiManager.cs
+++ b/Pigpio/SpiManager.cs
@@ -1,0 +1,31 @@
+﻿using Pigpio.Api;
+using System.Collections.Generic;
+
+namespace Pigpio
+{
+    public class SpiManager
+    {
+        private IPigpioApi api;
+        private Dictionary<int, SpiChannel> channels;
+
+        public SpiManager(IPigpioApi api)
+        {
+            this.api = api;
+            this.channels = new Dictionary<int, SpiChannel>();
+        }
+
+        public SpiChannel this[int ch]
+        {
+            get
+            {
+                if (this.channels.TryGetValue(ch, out var channel))
+                    return channel;
+
+                channel = new SpiChannel(this.api, ch);
+                this.channels[ch] = channel;
+
+                return channel;
+            }
+        }
+    }
+}

--- a/Ymf825.Pigpio/IO/PigpioSpi.cs
+++ b/Ymf825.Pigpio/IO/PigpioSpi.cs
@@ -62,7 +62,11 @@ namespace Ymf825.IO
             {
                 this.PinSS.Write(GpioPinLevel.Low);
 
+#if !NETSTANDARD2_0
                 Span<byte> buffer = stackalloc byte[2];
+#else
+                Span<byte> buffer = new byte[2];
+#endif
 
                 buffer[0] = command;
                 buffer[1] = data;
@@ -104,7 +108,11 @@ namespace Ymf825.IO
             {
                 this.PinSS.Write(GpioPinLevel.Low);
 
+#if !NETSTANDARD2_0
                 Span<byte> buffer = stackalloc byte[1];
+#else
+                Span<byte> buffer = new byte[1];
+#endif
                 buffer[0] = command;
 
                 this.SpiChannel.Write(buffer);

--- a/Ymf825.Pigpio/IO/PigpioSpi.cs
+++ b/Ymf825.Pigpio/IO/PigpioSpi.cs
@@ -1,0 +1,134 @@
+﻿using Pigpio;
+using System;
+using System.Threading;
+
+namespace Ymf825.IO
+{
+    public sealed class PigpioSpi : ISpi
+    {
+        public bool IsDisposed { get; private set; }
+
+        private SpiChannel SpiChannel { get; set; }
+
+        private GpioPin PinSS { get; set; }
+        private GpioPin PinRST { get; set; }
+
+        public PigpioSpi(PigpioClient pi)
+            : this(pi.Spi[0], pi.Gpio[25], pi.Gpio[16])
+        {
+        }
+
+        public PigpioSpi(SpiChannel spi, GpioPin pinSS, GpioPin pinRST)
+        {
+            this.InitializeSpi(spi);
+            this.InitializeGpio(pinSS, pinRST);
+        }
+
+        public void Dispose()
+        {
+            if (this.IsDisposed)
+                return;
+
+            this.SpiChannel.Dispose();
+
+            this.IsDisposed = true;
+        }
+
+        public void SetCsTargetPin(byte pin)
+        {
+        }
+
+        public void Write(byte command, byte data)
+        {
+            try
+            {
+                this.PinSS.Write(GpioPinLevel.Low);
+
+                Span<byte> buffer = stackalloc byte[2];
+
+                buffer[0] = command;
+                buffer[1] = data;
+
+                this.SpiChannel.Write(buffer);
+            }
+            finally
+            {
+                this.PinSS.Write(GpioPinLevel.High);
+            }
+        }
+
+        public void BurstWrite(byte command, byte[] data, int offset, int count)
+            => this.BurstWrite(command, data.AsSpan().Slice(offset, count));
+
+        public void BurstWrite(byte command, Span<byte> data)
+        {
+            try
+            {
+                this.PinSS.Write(GpioPinLevel.Low);
+
+                var bufferSize = data.Length + 1;
+                Span<byte> buffer = bufferSize < 128 ? stackalloc byte[bufferSize] : new byte[bufferSize];
+
+                buffer[0] = command;
+                data.CopyTo(buffer.Slice(1, data.Length));
+
+                this.SpiChannel.Write(buffer);
+            }
+            finally
+            {
+                this.PinSS.Write(GpioPinLevel.High);
+            }
+        }
+
+        public byte Read(byte command)
+        {
+            try
+            {
+                this.PinSS.Write(GpioPinLevel.Low);
+
+                Span<byte> buffer = stackalloc byte[1];
+                buffer[0] = command;
+
+                this.SpiChannel.Write(buffer);
+                this.SpiChannel.Read(buffer);
+
+                return buffer[0];
+            }
+            finally
+            {
+                this.PinSS.Write(GpioPinLevel.High);
+            }
+        }
+
+        public void Flush()
+        {
+        }
+
+        public void ResetHardware()
+        {
+            this.PinRST.Write(GpioPinLevel.Low);
+
+            Thread.Sleep(1);
+
+            this.PinRST.Write(GpioPinLevel.High);
+        }
+
+        private void InitializeSpi(SpiChannel spi)
+        {
+            const int frequency = 10_000_000;
+
+            this.SpiChannel = spi;
+            this.SpiChannel.Open(frequency, 0);
+        }
+
+        private void InitializeGpio(GpioPin pinSS, GpioPin pinRST)
+        {
+            this.PinSS = pinSS;
+            this.PinSS.PinMode = GpioPinMode.Output;
+            this.PinSS.Write(GpioPinLevel.High);
+
+            this.PinRST = pinRST;
+            this.PinRST.PinMode = GpioPinMode.Output;
+        }
+    }
+}

--- a/Ymf825.Pigpio/Ymf825.Pigpio.csproj
+++ b/Ymf825.Pigpio/Ymf825.Pigpio.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <RootNamespace>Ymf825</RootNamespace>
+    <LangVersion>latest</LangVersion>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+  </PropertyGroup>
+
+</Project>

--- a/Ymf825.Pigpio/Ymf825.Pigpio.csproj
+++ b/Ymf825.Pigpio/Ymf825.Pigpio.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
     <RootNamespace>Ymf825</RootNamespace>
     <LangVersion>latest</LangVersion>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>

--- a/Ymf825.Pigpio/Ymf825Pigpio.cs
+++ b/Ymf825.Pigpio/Ymf825Pigpio.cs
@@ -4,7 +4,7 @@ namespace Ymf825
 {
     public class Ymf825Pigpio : Ymf825
     {
-        public override TargetChip AvailableChip => TargetChip.Board0;
+        public override TargetChip AvailableChip => TargetChip.Board0 | TargetChip.Board1;
 
         public Ymf825Pigpio(PigpioSpi spiDevice)
             : base(spiDevice)

--- a/Ymf825.Pigpio/Ymf825Pigpio.cs
+++ b/Ymf825.Pigpio/Ymf825Pigpio.cs
@@ -1,0 +1,14 @@
+﻿using Ymf825.IO;
+
+namespace Ymf825
+{
+    public class Ymf825Pigpio : Ymf825
+    {
+        public override TargetChip AvailableChip => TargetChip.Board0;
+
+        public Ymf825Pigpio(PigpioSpi spiDevice)
+            : base(spiDevice)
+        {
+        }
+    }
+}

--- a/Ymf825.sln
+++ b/Ymf825.sln
@@ -11,6 +11,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ymf825.WiringPi", "Ymf825.W
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConsoleTestAppRaspberryPi", "ConsoleTestAppRaspberryPi\ConsoleTestAppRaspberryPi.csproj", "{4AC5A44C-ACE6-47CC-B09D-4CF258EEAF1E}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ymf825.Pigpio", "Ymf825.Pigpio\Ymf825.Pigpio.csproj", "{00507258-32D6-4F13-BD75-3A00A43A7A15}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +35,10 @@ Global
 		{4AC5A44C-ACE6-47CC-B09D-4CF258EEAF1E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4AC5A44C-ACE6-47CC-B09D-4CF258EEAF1E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4AC5A44C-ACE6-47CC-B09D-4CF258EEAF1E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{00507258-32D6-4F13-BD75-3A00A43A7A15}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{00507258-32D6-4F13-BD75-3A00A43A7A15}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{00507258-32D6-4F13-BD75-3A00A43A7A15}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{00507258-32D6-4F13-BD75-3A00A43A7A15}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Ymf825.sln
+++ b/Ymf825.sln
@@ -13,6 +13,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConsoleTestAppRaspberryPi",
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ymf825.Pigpio", "Ymf825.Pigpio\Ymf825.Pigpio.csproj", "{00507258-32D6-4F13-BD75-3A00A43A7A15}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Pigpio", "Pigpio\Pigpio.csproj", "{58449D06-11EA-441F-BCED-9182E24E91C0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pigpio.Socket", "Pigpio.Socket\Pigpio.Socket.csproj", "{352E3646-BA87-4FCD-A712-6209FEDEDC82}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -39,6 +43,14 @@ Global
 		{00507258-32D6-4F13-BD75-3A00A43A7A15}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{00507258-32D6-4F13-BD75-3A00A43A7A15}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{00507258-32D6-4F13-BD75-3A00A43A7A15}.Release|Any CPU.Build.0 = Release|Any CPU
+		{58449D06-11EA-441F-BCED-9182E24E91C0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{58449D06-11EA-441F-BCED-9182E24E91C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{58449D06-11EA-441F-BCED-9182E24E91C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{58449D06-11EA-441F-BCED-9182E24E91C0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{352E3646-BA87-4FCD-A712-6209FEDEDC82}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{352E3646-BA87-4FCD-A712-6209FEDEDC82}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{352E3646-BA87-4FCD-A712-6209FEDEDC82}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{352E3646-BA87-4FCD-A712-6209FEDEDC82}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Ymf825.sln
+++ b/Ymf825.sln
@@ -17,6 +17,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Pigpio", "Pigpio\Pigpio.csp
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pigpio.Socket", "Pigpio.Socket\Pigpio.Socket.csproj", "{352E3646-BA87-4FCD-A712-6209FEDEDC82}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pigpio.Native", "Pigpio.Native\Pigpio.Native.csproj", "{4575AB6C-8E34-4592-A681-1B8F28113995}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -51,6 +53,10 @@ Global
 		{352E3646-BA87-4FCD-A712-6209FEDEDC82}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{352E3646-BA87-4FCD-A712-6209FEDEDC82}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{352E3646-BA87-4FCD-A712-6209FEDEDC82}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4575AB6C-8E34-4592-A681-1B8F28113995}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4575AB6C-8E34-4592-A681-1B8F28113995}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4575AB6C-8E34-4592-A681-1B8F28113995}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4575AB6C-8E34-4592-A681-1B8F28113995}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
[pigpio](http://abyz.me.uk/rpi/pigpio/index.html) は Raspberry Pi の GPIO, SPI, I2C などの制御を行うためのライブラリ。[pigpiod](http://abyz.me.uk/rpi/pigpio/pigpiod.html) はそのデーモンで、ソケット (8888/tcp) または名前付きパイプ (`/dev/pigpio`) を介して操作できる。

WiringPi を使う場合と比べて、`/proc/cpuinfo` の Hardware, Revision に依存せず動いてくれる（はず）なので、今度こそ arm64 (aarch64) の Debian 上でも動かせるようになる。
ただし .NET Core の linux-arm は依然として armhf なので、ランタイムが arm64 で動くわけではない。